### PR TITLE
Fix PHP8.1 tentative return types

### DIFF
--- a/lib/Horde/Support/Array.php
+++ b/lib/Horde/Support/Array.php
@@ -146,6 +146,7 @@ class Horde_Support_Array implements ArrayAccess, Countable, IteratorAggregate
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_array);
@@ -153,6 +154,7 @@ class Horde_Support_Array implements ArrayAccess, Countable, IteratorAggregate
 
     /**
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->_array);
@@ -163,6 +165,7 @@ class Horde_Support_Array implements ArrayAccess, Countable, IteratorAggregate
      *
      * @see __get()
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->__get($offset);
@@ -173,6 +176,7 @@ class Horde_Support_Array implements ArrayAccess, Countable, IteratorAggregate
      *
      * @see __set()
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         return $this->__set($offset, $value);
@@ -183,6 +187,7 @@ class Horde_Support_Array implements ArrayAccess, Countable, IteratorAggregate
      *
      * @see __isset()
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->__isset($offset);
@@ -193,6 +198,7 @@ class Horde_Support_Array implements ArrayAccess, Countable, IteratorAggregate
      *
      * @see __unset()
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         return $this->__unset($offset);

--- a/lib/Horde/Support/CaseInsensitiveArray.php
+++ b/lib/Horde/Support/CaseInsensitiveArray.php
@@ -24,6 +24,7 @@ class Horde_Support_CaseInsensitiveArray extends ArrayIterator
 {
     /**
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return (is_null($offset = $this->_getRealOffset($offset)))
@@ -33,6 +34,7 @@ class Horde_Support_CaseInsensitiveArray extends ArrayIterator
 
     /**
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($roffset = $this->_getRealOffset($offset))) {
@@ -44,6 +46,7 @@ class Horde_Support_CaseInsensitiveArray extends ArrayIterator
 
     /**
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return !is_null($offset = $this->_getRealOffset($offset));
@@ -51,6 +54,7 @@ class Horde_Support_CaseInsensitiveArray extends ArrayIterator
 
     /**
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         if (!is_null($offset = $this->_getRealOffset($offset))) {

--- a/lib/Horde/Support/Stub.php
+++ b/lib/Horde/Support/Stub.php
@@ -95,6 +95,7 @@ class Horde_Support_Stub implements ArrayAccess, Countable, IteratorAggregate
 
      /**
       */
+    #[ReturnTypeWillChange]
      public function offsetGet($offset)
      {
          return null;
@@ -102,12 +103,14 @@ class Horde_Support_Stub implements ArrayAccess, Countable, IteratorAggregate
 
     /**
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
     }
 
     /**
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return false;
@@ -115,6 +118,7 @@ class Horde_Support_Stub implements ArrayAccess, Countable, IteratorAggregate
 
     /**
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
     }
@@ -123,6 +127,7 @@ class Horde_Support_Stub implements ArrayAccess, Countable, IteratorAggregate
 
     /**
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return 0;
@@ -132,6 +137,7 @@ class Horde_Support_Stub implements ArrayAccess, Countable, IteratorAggregate
 
     /**
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator(array());


### PR DESCRIPTION
```
PHP Deprecated:  Return type of Horde_Support_CaseInsensitiveArray::offsetExists($offset) should either be compatible with ArrayIterator::offsetExists(mixed $key): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/Imap_Client/Imap_Client/vendor/bytestream/horde-support/lib/Horde/Support/CaseInsensitiveArray.php on line 47
PHP Deprecated:  Return type of Horde_Support_CaseInsensitiveArray::offsetGet($offset) should either be compatible with ArrayIterator::offsetGet(mixed $key): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/Imap_Client/Imap_Client/vendor/bytestream/horde-support/lib/Horde/Support/CaseInsensitiveArray.php on line 27
PHP Deprecated:  Return type of Horde_Support_CaseInsensitiveArray::offsetSet($offset, $value) should either be compatible with ArrayIterator::offsetSet(mixed $key, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/Imap_Client/Imap_Client/vendor/bytestream/horde-support/lib/Horde/Support/CaseInsensitiveArray.php on line 36
PHP Deprecated:  Return type of Horde_Support_CaseInsensitiveArray::offsetUnset($offset) should either be compatible with ArrayIterator::offsetUnset(mixed $key): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/Imap_Client/Imap_Client/vendor/bytestream/horde-support/lib/Horde/Support/CaseInsensitiveArray.php on line 54
PHP Deprecated:  Return type of Horde_Support_Stub::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/Imap_Client/Imap_Client/vendor/bytestream/horde-support/lib/Horde/Support/Stub.php on line 126
PHP Deprecated:  Return type of Horde_Support_Stub::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/Imap_Client/Imap_Client/vendor/bytestream/horde-support/lib/Horde/Support/Stub.php on line 135
PHP Deprecated:  Return type of Horde_Support_Stub::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/Imap_Client/Imap_Client/vendor/bytestream/horde-support/lib/Horde/Support/Stub.php on line 111
PHP Deprecated:  Return type of Horde_Support_Stub::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/Imap_Client/Imap_Client/vendor/bytestream/horde-support/lib/Horde/Support/Stub.php on line 98
PHP Deprecated:  Return type of Horde_Support_Stub::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/Imap_Client/Imap_Client/vendor/bytestream/horde-support/lib/Horde/Support/Stub.php on line 105
PHP Deprecated:  Return type of Horde_Support_Stub::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/Imap_Client/Imap_Client/vendor/bytestream/horde-support/lib/Horde/Support/Stub.php on line 118
```