### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Support/Inflector.php
+++ b/lib/Horde/Support/Inflector.php
@@ -17,6 +17,7 @@
  * @package    Support
  * @license    http://www.horde.org/licenses/bsd
  */
+#[\AllowDynamicProperties]
 class Horde_Support_Inflector
 {
     /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <phpunit bootstrap="test/Horde/Support/bootstrap.php" colors="true">
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Support Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>

--- a/test/Horde/Support/ArrayTest.php
+++ b/test/Horde/Support/ArrayTest.php
@@ -14,7 +14,7 @@
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
-class Horde_Support_ArrayTest extends PHPUnit_Framework_TestCase
+class Horde_Support_ArrayTest extends Horde_Test_Case
 {
     public function testImplementsArrayAccess()
     {
@@ -137,12 +137,16 @@ class Horde_Support_ArrayTest extends PHPUnit_Framework_TestCase
 
     public function testUpdateDoesNotThrowWhenArgumentIsAnArray()
     {
+        $this->expectNotToPerformAssertions();
+
         $o = new Horde_Support_Array();
         $o->update(array());
     }
 
     public function testUpdateDoesNotThrowWhenArgumentIsTraversable()
     {
+        $this->expectNotToPerformAssertions();
+
         $o = new Horde_Support_Array();
         $o->update(new ArrayObject());
     }

--- a/test/Horde/Support/BacktraceTest.php
+++ b/test/Horde/Support/BacktraceTest.php
@@ -83,6 +83,9 @@ class Horde_Support_BacktraceTest extends Horde_Test_Case
         $this->assertEquals(count($dbt), $backtrace->getNestingLevel());
     }
 
+/*
+ * DEACTIVATED: This test fails with every change in PHPUnit. Not appropriate for a distro package.
+ *
     public function testToString()
     {
         $backtrace = new Horde_Support_Backtrace(array_slice($this->instanceMethod(), 0, 4));
@@ -94,6 +97,8 @@ class Horde_Support_BacktraceTest extends Horde_Test_Case
 ",
                             (string)$backtrace);
     }
+ *
+ */
 
     public function returnBacktrace()
     {

--- a/test/Horde/Support/BacktraceTest.php
+++ b/test/Horde/Support/BacktraceTest.php
@@ -19,7 +19,7 @@ function backtraceTestFunction()
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
-class Horde_Support_BacktraceTest extends PHPUnit_Framework_TestCase
+class Horde_Support_BacktraceTest extends Horde_Test_Case
 {
     // Keep these two methods on the top so that the line numbers don't change
     // when new tests are added.
@@ -87,7 +87,7 @@ class Horde_Support_BacktraceTest extends PHPUnit_Framework_TestCase
     {
         $backtrace = new Horde_Support_Backtrace(array_slice($this->instanceMethod(), 0, 4));
         $file = __FILE__;
-        $this->assertEquals("1. Horde_Support_BacktraceTest->testToString()
+        $this->assertEquals("1. Horde_Support_BacktraceTest->testToString() /usr/share/php/PHPUnit/Framework/TestCase.php:1408
 2. Horde_Support_BacktraceTest->instanceMethod() $file:88
 3. Horde_Support_BacktraceTest::staticMethod() $file:28
 4. backtraceTestFunction() $file:33

--- a/test/Horde/Support/CaseInsensitiveArrayTest.php
+++ b/test/Horde/Support/CaseInsensitiveArrayTest.php
@@ -16,7 +16,7 @@
  * @package    Support
  * @subpackage UnitTests
  */
-class Horde_Support_CaseInsensitiveArrayTest extends PHPUnit_Framework_TestCase
+class Horde_Support_CaseInsensitiveArrayTest extends Horde_Test_Case
 {
     /**
      * @dataProvider implementsProvider

--- a/test/Horde/Support/CombineStreamTest.php
+++ b/test/Horde/Support/CombineStreamTest.php
@@ -14,7 +14,7 @@
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
-class Horde_Support_CombineStreamTest extends PHPUnit_Framework_TestCase
+class Horde_Support_CombineStreamTest extends Horde_Test_Case
 {
     public function testUsage()
     {

--- a/test/Horde/Support/ConsistentHashTest.php
+++ b/test/Horde/Support/ConsistentHashTest.php
@@ -14,30 +14,32 @@
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
-class Horde_Support_ConsistentHashTest extends PHPUnit_Framework_TestCase
+class Horde_Support_ConsistentHashTest extends Horde_Test_Case
 {
     public function testAddUpdatesCount()
     {
         $h = new Horde_Support_ConsistentHash;
-        $this->assertEquals(0, $this->readAttribute($h, '_nodeCount'));
+        $this->assertEquals(0, $this->getPrivatePropertyValue($h, '_nodeCount'));
 
         $h->add('a');
-        $this->assertEquals(1, $this->readAttribute($h, '_nodeCount'));
-        $this->assertEquals(count($this->readAttribute($h, '_nodes')), $this->readAttribute($h, '_nodeCount'));
+        $this->assertEquals(1, $this->getPrivatePropertyValue($h, '_nodeCount'));
+        $this->assertEquals(count($this->getPrivatePropertyValue($h, '_nodes')), $this->getPrivatePropertyValue($h, '_nodeCount'));
     }
+
+    // https://www.webtipblog.com/unit-testing-private-methods-and-properties-with-phpunit/
 
     public function testAddUpdatesPointCount()
     {
         $numberOfReplicas = 100;
         $h = new Horde_Support_ConsistentHash(array(), 1, $numberOfReplicas);
-        $this->assertEquals(0, $this->readAttribute($h, '_pointCount'));
-        $this->assertEquals(count($this->readAttribute($h, '_circle')), $this->readAttribute($h, '_pointCount'));
-        $this->assertEquals(count($this->readAttribute($h, '_pointMap')), $this->readAttribute($h, '_pointCount'));
+        $this->assertEquals(0, $this->getPrivatePropertyValue($h, '_pointCount'));
+        $this->assertEquals(count($this->getPrivatePropertyValue($h, '_circle')), $this->getPrivatePropertyValue($h, '_pointCount'));
+        $this->assertEquals(count($this->getPrivatePropertyValue($h, '_pointMap')), $this->getPrivatePropertyValue($h, '_pointCount'));
 
         $h->add('a');
-        $this->assertEquals(100, $this->readAttribute($h, '_pointCount'));
-        $this->assertEquals(count($this->readAttribute($h, '_circle')), $this->readAttribute($h, '_pointCount'));
-        $this->assertEquals(count($this->readAttribute($h, '_pointMap')), $this->readAttribute($h, '_pointCount'));
+        $this->assertEquals(100, $this->getPrivatePropertyValue($h, '_pointCount'));
+        $this->assertEquals(count($this->getPrivatePropertyValue($h, '_circle')), $this->getPrivatePropertyValue($h, '_pointCount'));
+        $this->assertEquals(count($this->getPrivatePropertyValue($h, '_pointMap')), $this->getPrivatePropertyValue($h, '_pointCount'));
     }
 
     public function testAddWithWeightGeneratesMorePoints()
@@ -45,33 +47,33 @@ class Horde_Support_ConsistentHashTest extends PHPUnit_Framework_TestCase
         $weight = 2;
         $numberOfReplicas = 100;
         $h = new Horde_Support_ConsistentHash(array(), 1, $numberOfReplicas);
-        $this->assertEquals(0, $this->readAttribute($h, '_pointCount'));
-        $this->assertEquals(count($this->readAttribute($h, '_circle')), $this->readAttribute($h, '_pointCount'));
-        $this->assertEquals(count($this->readAttribute($h, '_pointMap')), $this->readAttribute($h, '_pointCount'));
+        $this->assertEquals(0, $this->getPrivatePropertyValue($h, '_pointCount'));
+        $this->assertEquals(count($this->getPrivatePropertyValue($h, '_circle')), $this->getPrivatePropertyValue($h, '_pointCount'));
+        $this->assertEquals(count($this->getPrivatePropertyValue($h, '_pointMap')), $this->getPrivatePropertyValue($h, '_pointCount'));
 
         $h->add('a', $weight);
-        $this->assertEquals($numberOfReplicas * $weight, $this->readAttribute($h, '_pointCount'));
-        $this->assertEquals(count($this->readAttribute($h, '_circle')), $this->readAttribute($h, '_pointCount'));
-        $this->assertEquals(count($this->readAttribute($h, '_pointMap')), $this->readAttribute($h, '_pointCount'));
+        $this->assertEquals($numberOfReplicas * $weight, $this->getPrivatePropertyValue($h, '_pointCount'));
+        $this->assertEquals(count($this->getPrivatePropertyValue($h, '_circle')), $this->getPrivatePropertyValue($h, '_pointCount'));
+        $this->assertEquals(count($this->getPrivatePropertyValue($h, '_pointMap')), $this->getPrivatePropertyValue($h, '_pointCount'));
     }
 
     public function testRemoveRemovesPoints()
     {
         $h = new Horde_Support_ConsistentHash;
-        $this->assertEquals(0, $this->readAttribute($h, '_nodeCount'));
+        $this->assertEquals(0, $this->getPrivatePropertyValue($h, '_nodeCount'));
 
         $h->add('a');
         $h->remove('a');
-        $this->assertEquals(0, $this->readAttribute($h, '_nodeCount'));
-        $this->assertEquals(0, $this->readAttribute($h, '_pointCount'));
-        $this->assertEquals(count($this->readAttribute($h, '_circle')), $this->readAttribute($h, '_pointCount'));
-        $this->assertEquals(count($this->readAttribute($h, '_pointMap')), $this->readAttribute($h, '_pointCount'));
+        $this->assertEquals(0, $this->getPrivatePropertyValue($h, '_nodeCount'));
+        $this->assertEquals(0, $this->getPrivatePropertyValue($h, '_pointCount'));
+        $this->assertEquals(count($this->getPrivatePropertyValue($h, '_circle')), $this->getPrivatePropertyValue($h, '_pointCount'));
+        $this->assertEquals(count($this->getPrivatePropertyValue($h, '_pointMap')), $this->getPrivatePropertyValue($h, '_pointCount'));
     }
 
     public function testRemoveThrowsOnNonexistentNode()
     {
         $h = new Horde_Support_ConsistentHash;
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $h->remove('a');
     }
 
@@ -152,13 +154,15 @@ class Horde_Support_ConsistentHashTest extends PHPUnit_Framework_TestCase
         $h = new Horde_Support_ConsistentHash(range(1, 10));
         $nodes = $h->getNodes('r', 2);
 
-        $this->assertInternalType('array', $nodes);
+        $this->assertIsArray($nodes);
         $this->assertEquals(count($nodes), 2);
         $this->assertNotEquals($nodes[0], $nodes[1]);
     }
 
     public function testGetNodesWithNotEnoughNodes()
     {
+        $this->expectNotToPerformAssertions();
+
         $h = new Horde_Support_ConsistentHash(array('t'));
 
         try {

--- a/test/Horde/Support/GuidTest.php
+++ b/test/Horde/Support/GuidTest.php
@@ -20,7 +20,7 @@ class Horde_Support_GuidTest extends Horde_Test_Case
     {
         $guid = new Horde_Support_Guid(array('server' => 'localhost'));
         $this->assertEquals(48, strlen($guid));
-        $this->assertRegExp('/\d{14}\.[-_0-9a-zA-Z]{23}@localhost/', (string)$guid);
+        $this->assertMatchesRegularExpression('/\d{14}\.[-_0-9a-zA-Z]{23}@localhost/', (string)$guid);
     }
 
     public function testDuplicates()
@@ -37,6 +37,6 @@ class Horde_Support_GuidTest extends Horde_Test_Case
     public function testOptions()
     {
         $this->assertStringEndsWith('example.com', (string)new Horde_Support_Guid(array('server' => 'example.com')));
-        $this->assertRegExp('/\d{14}\.prefix\.[-_0-9a-zA-Z]{23}@localhost/', (string)new Horde_Support_Guid(array('prefix' => 'prefix', 'server' => 'localhost')));
+        $this->assertMatchesRegularExpression('/\d{14}\.prefix\.[-_0-9a-zA-Z]{23}@localhost/', (string)new Horde_Support_Guid(array('prefix' => 'prefix', 'server' => 'localhost')));
     }
 }

--- a/test/Horde/Support/GuidTest.php
+++ b/test/Horde/Support/GuidTest.php
@@ -14,7 +14,7 @@
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
-class Horde_Support_GuidTest extends PHPUnit_Framework_TestCase
+class Horde_Support_GuidTest extends Horde_Test_Case
 {
     public function testFormat()
     {

--- a/test/Horde/Support/InflectorTest.php
+++ b/test/Horde/Support/InflectorTest.php
@@ -14,7 +14,7 @@
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
-class Horde_Support_InflectorTest extends PHPUnit_Framework_TestCase
+class Horde_Support_InflectorTest extends Horde_Test_Case
 {
     /**
      * Words to test
@@ -37,7 +37,7 @@ class Horde_Support_InflectorTest extends PHPUnit_Framework_TestCase
         'mouse' => 'mice',
     );
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->inflector = new Horde_Support_Inflector;
     }

--- a/test/Horde/Support/InflectorTest.php
+++ b/test/Horde/Support/InflectorTest.php
@@ -14,6 +14,7 @@
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
+#[\AllowDynamicProperties]
 class Horde_Support_InflectorTest extends Horde_Test_Case
 {
     /**

--- a/test/Horde/Support/MemoryTest.php
+++ b/test/Horde/Support/MemoryTest.php
@@ -14,19 +14,19 @@
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
-class Horde_Support_MemoryTest extends PHPUnit_Framework_TestCase
+class Horde_Support_MemoryTest extends Horde_Test_Case
 {
     public function testMemoryStart()
     {
         $t = new Horde_Support_Memory;
-        $this->assertInternalType('array', $t->push());
+        $this->assertIsArray($t->push());
     }
 
     public function testMemoryEnd()
     {
         $t = new Horde_Support_Memory;
         $t->push();
-        $this->assertInternalType('array', $t->pop());
+        $this->assertIsArray($t->pop());
     }
 
     public function testStartValues()
@@ -53,6 +53,8 @@ class Horde_Support_MemoryTest extends PHPUnit_Framework_TestCase
 
     public function testNotPushedThrowsException()
     {
+        $this->expectNotToPerformAssertions();
+
         $t = new Horde_Support_Memory();
         try {
             $t->pop();

--- a/test/Horde/Support/Numerizer/Locale/BaseTest.php
+++ b/test/Horde/Support/Numerizer/Locale/BaseTest.php
@@ -10,7 +10,7 @@
  * @package    Support
  * @subpackage UnitTests
  */
-class Horde_Support_Numerizer_Locale_BaseTest extends PHPUnit_Framework_TestCase
+class Horde_Support_Numerizer_Locale_BaseTest extends Horde_Test_Case
 {
     public function testStraightParsing()
     {

--- a/test/Horde/Support/Numerizer/Locale/DeTest.php
+++ b/test/Horde/Support/Numerizer/Locale/DeTest.php
@@ -10,7 +10,7 @@
  * @package    Support
  * @subpackage UnitTests
  */
-class Horde_Support_Numerizer_Locale_DeTest extends PHPUnit_Framework_TestCase
+class Horde_Support_Numerizer_Locale_DeTest extends Horde_Test_Case
 {
     public function testStraightParsing()
     {

--- a/test/Horde/Support/ObjectStubTest.php
+++ b/test/Horde/Support/ObjectStubTest.php
@@ -14,7 +14,7 @@
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
-class Horde_Support_ObjectStubTest extends PHPUnit_Framework_TestCase
+class Horde_Support_ObjectStubTest extends Horde_Test_Case
 {
     public function testUndefinedIndex()
     {

--- a/test/Horde/Support/RandomidTest.php
+++ b/test/Horde/Support/RandomidTest.php
@@ -14,7 +14,7 @@
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
-class Horde_Support_RandomidTest extends PHPUnit_Framework_TestCase
+class Horde_Support_RandomidTest extends Horde_Test_Case
 {
     public function testLength()
     {

--- a/test/Horde/Support/StackTest.php
+++ b/test/Horde/Support/StackTest.php
@@ -14,10 +14,12 @@
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
-class Horde_Support_StackTest extends PHPUnit_Framework_TestCase
+class Horde_Support_StackTest extends Horde_Test_Case
 {
     public function testEmptyConstructor()
     {
+        $this->expectNotToPerformAssertions();
+
         return new Horde_Support_Stack();
     }
 
@@ -26,6 +28,8 @@ class Horde_Support_StackTest extends PHPUnit_Framework_TestCase
      */
     public function testPushOnEmptyStack($stack)
     {
+        $this->expectNotToPerformAssertions();
+
         $stack->push('one');
         $stack->push('two');
         return $stack;
@@ -55,6 +59,8 @@ class Horde_Support_StackTest extends PHPUnit_Framework_TestCase
 
     public function testPrefilledConstructor()
     {
+        $this->expectNotToPerformAssertions();
+
         return new Horde_Support_Stack(array('foo', 'bar'));
     }
 
@@ -72,6 +78,8 @@ class Horde_Support_StackTest extends PHPUnit_Framework_TestCase
      */
     public function testPushOnPrefilledStack($stack)
     {
+        $this->expectNotToPerformAssertions();
+
         $stack->push('baz');
         return $stack;
     }

--- a/test/Horde/Support/StringStreamTest.php
+++ b/test/Horde/Support/StringStreamTest.php
@@ -14,7 +14,7 @@
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
-class Horde_Support_StringStreamTest extends PHPUnit_Framework_TestCase
+class Horde_Support_StringStreamTest extends Horde_Test_Case
 {
     public function testMemoryUsage()
     {

--- a/test/Horde/Support/StubTest.php
+++ b/test/Horde/Support/StubTest.php
@@ -14,7 +14,7 @@
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
-class Horde_Support_StubTest extends PHPUnit_Framework_TestCase
+class Horde_Support_StubTest extends Horde_Test_Case
 {
     public function testAnyOffsetIsGettable()
     {

--- a/test/Horde/Support/TimerTest.php
+++ b/test/Horde/Support/TimerTest.php
@@ -14,7 +14,7 @@
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
-class Horde_Support_TimerTest extends PHPUnit_Framework_TestCase
+class Horde_Support_TimerTest extends Horde_Test_Case
 {
     /**
      * test instantiating a normal timer
@@ -35,6 +35,8 @@ class Horde_Support_TimerTest extends PHPUnit_Framework_TestCase
      */
     public function testNotStartedYetThrowsException()
     {
+        $this->expectNotToPerformAssertions();
+
         $t = new Horde_Support_Timer();
         try {
             $t->pop();

--- a/test/Horde/Support/UuidTest.php
+++ b/test/Horde/Support/UuidTest.php
@@ -14,7 +14,7 @@
  * @subpackage UnitTests
  * @license    http://www.horde.org/licenses/bsd
  */
-class Horde_Support_UuidTest extends PHPUnit_Framework_TestCase
+class Horde_Support_UuidTest extends Horde_Test_Case
 {
     public function testLength()
     {

--- a/test/Horde/Support/phpunit.xml
+++ b/test/Horde/Support/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API https://salsa.debian.org/horde-team/php-horde-support/-/blob/debian-sid/debian/patches/1001_phpunit-8.x%2B9.x.patch
- Debian changes: Add 1002_re-ad-phpunit-xml.patch. Add 1003_php8.1.patch. https://salsa.debian.org/horde-team/php-horde-support/-/blob/debian-sid/debian/patches/1003_php8.1.patch
- Debian changes: Add 1013_php8.2.patch. Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-support/-/blob/debian-sid/debian/patches/1013_php8.2.patch
